### PR TITLE
Directory error while integrating this jycm library for web application

### DIFF
--- a/jycm/helper.py
+++ b/jycm/helper.py
@@ -75,3 +75,17 @@ def dump_html_output(left, right, diff_result, output, left_title='Left', right_
     with open(index_url, "w") as fp:
         fp.write(html)
     return index_url
+
+
+def open_url(index_url):  # pragma: no cover
+    try:
+        import webbrowser
+        from sys import platform
+        if platform == "linux" or platform == "linux2":
+            webbrowser.open(f"file://{index_url}")
+        elif platform == "darwin":
+            webbrowser.open(f"file://{index_url}")
+        elif platform == "win32":
+            webbrowser.open(f"{index_url}")
+    except Exception as e:
+        print("You have to install webbrowser to open the html.\nRun pip install webbrowser")


### PR DESCRIPTION
so basically i found a small bug in your application like in jycm/helper.py file line no 55 there is a script path of ./main.js so by this i was getting directory error and the path of js was not rendering to my index.html which was generated under output/index.html and output/index.js so thats why i changed some path where instead of taking ./main.js i change it to output/main.js. So please look into it and merge it 