### PR TITLE
 Directory error while integrating this jycm library for web application 

### DIFF
--- a/jycm/helper.py
+++ b/jycm/helper.py
@@ -52,7 +52,7 @@ HTML_TEMPLATE = """
 """.strip()
 
 
-def render_to_html(left, right, diff_result, main_script_path="./index.js", left_title='Left', right_title='Right'):
+def render_to_html(left, right, diff_result, main_script_path, left_title='Left', right_title='Right'):
     return HTML_TEMPLATE.replace(
         "__MAIN_SCRIPT_PATH__", f"{main_script_path}"
     ).replace(
@@ -68,7 +68,7 @@ def render_to_html(left, right, diff_result, main_script_path="./index.js", left
 
 
 def dump_html_output(left, right, diff_result, output, left_title='Left', right_title='Right'):
-    html = render_to_html(left, right, diff_result, left_title=left_title, right_title=right_title)
+    html = render_to_html(left, right, diff_result, main_script_path=os.path.join(os.getcwd(),f"{output}/index.js"),left_title=left_title, right_title=right_title)
 
     shutil.copytree(os.path.join(os.path.dirname(os.path.realpath(__file__)), "jycm_viewer_assets/"), output)
     index_url = os.path.join(output, "index.html")

--- a/jycm/helper.py
+++ b/jycm/helper.py
@@ -75,3 +75,17 @@ def dump_html_output(left, right, diff_result, output, left_title='Left', right_
     with open(index_url, "w") as fp:
         fp.write(html)
     return index_url
+
+
+def open_url(index_url):  # pragma: no cover
+    try:
+        import webbrowser
+        from sys import platform
+        if platform == "linux" or platform == "linux2":
+            webbrowser.open(f"file://{index_url}")
+        elif platform == "darwin":
+            webbrowser.open(f"file://{index_url}")
+        elif platform == "win32":
+            webbrowser.open(f"{index_url}")
+    except Exception as e:
+        print("You have to install webbrowser to open the html.\nRun pip install webbrowser")

--- a/jycm/helper.py
+++ b/jycm/helper.py
@@ -68,7 +68,7 @@ def render_to_html(left, right, diff_result, main_script_path, left_title='Left'
 
 
 def dump_html_output(left, right, diff_result, output, left_title='Left', right_title='Right'):
-    html = render_to_html(left, right, diff_result, main_script_path=os.path.join(os.getcwd(),f"{output}/index.js"),left_title=left_title, right_title=right_title)
+    html = render_to_html(left, right, diff_result, main_script_path=f"{output}/index.js",left_title=left_title, right_title=right_title)
 
     shutil.copytree(os.path.join(os.path.dirname(os.path.realpath(__file__)), "jycm_viewer_assets/"), output)
     index_url = os.path.join(output, "index.html")


### PR DESCRIPTION
so basically i found a small bug in your application like in jycm/helper.py file line no 55 there is a script path of ./main.js so by this i was getting directory error and the path of js was not rendering to my index.html which was generated under output/index.html and output/index.js so thats why i changed some path where instead of taking ./main.js i change it to output/main.js. So please look into it and merge it