### PR TITLE
Add business diff policies, JSON Patch, and portable Agent Skill

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -1,19 +1,23 @@
 name: Python package
 
-on: [push]
+on:
+  push:
+    branches: [master]
+  pull_request:
 
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -21,7 +25,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
-          pip install coveralls
 
       - name: Lint
         run: |
@@ -34,7 +37,9 @@ jobs:
           PYTHONPATH: "./"
 
       - name: Coveralls
+        if: matrix.python-version == '3.12'
         run: |
+          pip install coveralls
           coveralls --service=github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -15,9 +15,9 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,29 @@ patch = differ.to_json_patch()  # uses the same business semantics
 violations, matched-pair totals, and the structured diff. Policies also accept
 the original `value` / `parameter` rule shape for backward compatibility.
 
+### Agent Skill for Codex and Claude
+
+This repository includes the portable `jycm-business-diff` Agent Skill. It
+teaches compatible coding agents to design Policy rules from business examples,
+validate fixtures, generate and verify Patch, integrate the React UI, and plan
+safe deployment.
+
+```bash
+# user-wide Codex installation
+python skills/jycm-business-diff/scripts/install_skill.py --client codex
+
+# user-wide Claude Code installation
+python skills/jycm-business-diff/scripts/install_skill.py --client claude
+
+# open Agent Skills project installation
+python skills/jycm-business-diff/scripts/install_skill.py --client agents --project .
+```
+
+The canonical skill follows the open Agent Skills `SKILL.md` format and includes
+policy/deployment references plus a deterministic validation and comparison
+workflow. Existing installs are never overwritten unless `--force` is passed;
+the installer creates a timestamped backup first.
+
 # Renderer
 Yes! JYCM has a [rendering tool](https://github.com/eggachecat/react-jycm-viewer) out of the box!
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,50 @@ See [https://eggachecat.github.io/jycm-json-diff-viewer](https://eggachecat.gith
 # Install
 > pip install jycm
 
+## Business Diff Policy
+
+Define domain equality as versioned, serializable data and reuse the same policy
+in Python and JavaScript. Rules can ignore volatile fields, compare unordered
+collections, pair records by identity, normalize text, apply absolute or
+relative numeric tolerances, and assert expected values or changes.
+
+```python
+from jycm import BusinessDiffPolicy
+
+policy = BusinessDiffPolicy({
+    "version": 1,
+    "name": "order-contract",
+    "rules": [
+        {"name": "items-as-set", "path": "^items$", "operation": "unordered"},
+        {
+            "name": "match-sku",
+            "path": r"^items->\[\d+\]$",
+            "operation": "match_by",
+            "options": {"field": "sku"},
+        },
+        {
+            "name": "money-rounding",
+            "path": r"^items->\[\d+\]->price$",
+            "operation": "numeric_tolerance",
+            "options": {"absolute": 0.01, "relative": 0.001},
+        },
+        {"name": "trace-id", "path": "^trace_id$", "operation": "ignore"},
+    ],
+})
+
+explanation = policy.compare(before, after)
+print(explanation["equal"])
+print(explanation["summary"])
+print(explanation["violations"])
+
+differ = policy.build(before, after)
+patch = differ.to_json_patch()  # uses the same business semantics
+```
+
+`explain()` returns dashboard-ready counts, affected paths, named rule
+violations, matched-pair totals, and the structured diff. Policies also accept
+the original `value` / `parameter` rule shape for backward compatibility.
+
 # Renderer
 Yes! JYCM has a [rendering tool](https://github.com/eggachecat/react-jycm-viewer) out of the box!
 

--- a/README.md
+++ b/README.md
@@ -222,6 +222,47 @@ expected = {
 assert ycm.to_dict(no_pairs=True) == expected
 
 ```
+
+## Generate and apply JSON Patch
+
+JYCM can produce and apply standard [RFC 6902 JSON Patch](https://www.rfc-editor.org/rfc/rfc6902)
+operations. The generated patch follows the same business rules as the diff: ignored paths,
+order-insensitive arrays, and custom operators that consider a value equivalent are left untouched.
+
+```python
+from jycm import apply_json_patch
+from jycm.jycm import YouchamaJsonDiffer
+from jycm.operator import IgnoreOperator
+
+before = {
+    "order": {"status": "pending", "total": 100},
+    "generated_at": "2024-01-01T00:00:00Z",
+}
+after = {
+    "order": {"status": "paid", "total": 100},
+    "generated_at": "2024-01-02T00:00:00Z",
+}
+
+differ = YouchamaJsonDiffer(
+    before,
+    after,
+    custom_operators=[IgnoreOperator("^generated_at$")],
+)
+
+# `test` operations make stale writes fail instead of silently overwriting data.
+patch = differ.to_json_patch(include_tests=True)
+assert patch == [
+    {"op": "test", "path": "/order/status", "value": "pending"},
+    {"op": "replace", "path": "/order/status", "value": "paid"},
+]
+
+updated = apply_json_patch(before, patch)
+# Or: updated = differ.apply_patch()
+```
+
+`apply_json_patch` supports all RFC 6902 operations: `add`, `remove`, `replace`,
+`move`, `copy`, and `test`. It copies the input by default; pass `in_place=True`
+only when mutation is intentional.
 ### Graph
 ![default_behaviour](https://raw.githubusercontent.com/eggachecat/jycm/master/docs/source/images/examples/default_behaviour.png)
 

--- a/jycm/__init__.py
+++ b/jycm/__init__.py
@@ -7,5 +7,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from .__version__ import __version__  # NOQA
 from .patch import JsonPatchError, JsonPatchTestFailed, apply_json_patch, make_json_patch  # NOQA
+from .policy import BusinessDiffPolicy, BusinessPolicyError  # NOQA
 
 __author__ = 'eggachecat <sunao_0626@hotmail.com>'

--- a/jycm/__init__.py
+++ b/jycm/__init__.py
@@ -6,5 +6,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from .__version__ import __version__  # NOQA
+from .patch import JsonPatchError, JsonPatchTestFailed, apply_json_patch, make_json_patch  # NOQA
 
 __author__ = 'eggachecat <sunao_0626@hotmail.com>'

--- a/jycm/jycm.py
+++ b/jycm/jycm.py
@@ -275,44 +275,34 @@ class YouchamaJsonDiffer:
         """Inner function to find the longest common subsequence of string `X[0…m-1]` and `Y[0…n-1]`
 
         """
-        # return an empty string if the end of either sequence is reached
-        if left_size == 0 or right_size == 0:
-            return []
+        # Backtrack iteratively. The former recursive implementation used one
+        # Python stack frame per matched/list item and failed around 1,000
+        # elements even though the LCS table had already been built.
+        pairs = []
+        while left_size > 0 and right_size > 0:
+            pair_level = TreeLevel(
+                left=level.left[left_size - 1],
+                right=level.right[right_size - 1],
+                left_path=[*level.left_path, left_size - 1],
+                right_path=[*level.right_path, right_size - 1],
+                up=level
+            )
 
-        # if the last character of `X` and `Y` matches
-        # if left[left_size - 1] == right[right_size - 1]:
-        if self.diff_level(TreeLevel(
-            left=level.left[left_size - 1],
-            right=level.right[right_size - 1],
-            left_path=[*level.left_path, left_size - 1],
-            right_path=[*level.right_path, right_size - 1],
-            up=level
-        ), drill=True) == 1:
-            # append current character (`X[m-1]` or `Y[n-1]`) to LCS of
-            # substring `X[0…m-2]` and `Y[0…n-2]`
-            return self._generate_lcs_pair_list(level, left_size - 1, right_size - 1, dp_table) + [
-                ListItemPair(value=TreeLevel(
-                    left=level.left[left_size - 1],
-                    right=level.right[right_size - 1],
-                    left_path=[*level.left_path, left_size - 1],
-                    right_path=[*level.right_path, right_size - 1],
-                    up=level
-                ), left_index=left_size - 1, right_index=right_size - 1)
-            ]
+            if self.diff_level(pair_level, drill=True) == 1:
+                pairs.append(ListItemPair(
+                    value=pair_level,
+                    left_index=left_size - 1,
+                    right_index=right_size - 1
+                ))
+                left_size -= 1
+                right_size -= 1
+            elif dp_table[left_size - 1][right_size] > dp_table[left_size][right_size - 1]:
+                left_size -= 1
+            else:
+                right_size -= 1
 
-        # otherwise, if the last character of `X` and `Y` are different
-
-        # if a top cell of the current cell has more value than the left
-        # cell, then drop the current character of string `X` and find LCS
-        # of substring `X[0…m-2]`, `Y[0…n-1]`
-
-        if dp_table[left_size - 1][right_size] > dp_table[left_size][right_size - 1]:
-            return self._generate_lcs_pair_list(level, left_size - 1, right_size, dp_table)
-        else:
-            # if a left cell of the current cell has more value than the top
-            # cell, then drop the current character of string `Y` and find LCS
-            # of substring `X[0…m-1]`, `Y[0…n-2]`
-            return self._generate_lcs_pair_list(level, left_size, right_size - 1, dp_table)
+        pairs.reverse()
+        return pairs
 
     def _build_up_lcs_table(self, level: TreeLevel, left_size, right_size, dp_table):
         """Inner function
@@ -926,3 +916,73 @@ class YouchamaJsonDiffer:
         """
         self.diff()
         return self.to_dict(no_pairs)
+
+    def to_json_patch(self, include_tests=False):
+        """Return an RFC 6902 JSON Patch from ``left`` to ``right``.
+
+        JYCM's semantic comparison rules are respected. A path considered
+        equal by an ignore rule or custom operator is intentionally omitted
+        from the patch.
+
+        Args:
+            include_tests: add a ``test`` operation before destructive writes.
+        """
+        from jycm.patch import make_json_patch
+
+        class PatchContext:
+            """Delegate operator helpers while keeping patch generation read-only."""
+
+            def __init__(self, differ):
+                self.differ = differ
+
+            def report(self, event, level, info=None):
+                pass
+
+            def __getattr__(self, name):
+                return getattr(self.differ, name)
+
+        patch_context = PatchContext(self)
+
+        def equivalent(left, right, left_path, right_path):
+            level = TreeLevel(
+                left=left,
+                right=right,
+                left_path=left_path,
+                right_path=right_path,
+                up=None
+            )
+
+            # Operators may use drill mode only to identify list-item pairs.
+            # Evaluate their final (non-drill) decision so matching operators
+            # can continue into child fields while ignore/tolerance operators
+            # can intentionally suppress a patch.
+            for operator in self.custom_operators:
+                if operator.match(level):
+                    skip, score = operator.diff(level, patch_context, drill=False)
+                    if skip:
+                        return score == 1
+
+            # An order-insensitive list is equivalent only when JYCM's full
+            # matching algorithm says so; otherwise positional patching still
+            # guarantees a deterministic transformation.
+            if isinstance(left, list) and self.ignore_order_func(level, False):
+                return self.diff_level(level, drill=True) == 1
+
+            return False
+
+        return make_json_patch(
+            self.left,
+            self.right,
+            equivalent=equivalent,
+            include_tests=include_tests
+        )
+
+    def apply_patch(self, document=None, patch=None, in_place=False):
+        """Apply an RFC 6902 patch, defaulting to this comparison's patch."""
+        from jycm.patch import apply_json_patch
+
+        if document is None:
+            document = self.left
+        if patch is None:
+            patch = self.to_json_patch()
+        return apply_json_patch(document, patch, in_place=in_place)

--- a/jycm/jycm.py
+++ b/jycm/jycm.py
@@ -213,6 +213,16 @@ class YouchamaJsonDiffer:
         self.ignore_order_func: Callable[[TreeLevel, bool], bool] = ignore_order_func
 
         self.event_pair_dict: Dict[str, bool] = {}
+        self.business_policy = None
+
+    @classmethod
+    def from_policy(cls, left, right, policy, **differ_options):
+        """Create a differ from a serializable :class:`BusinessDiffPolicy`."""
+        from jycm.policy import BusinessDiffPolicy
+
+        if not isinstance(policy, BusinessDiffPolicy):
+            policy = BusinessDiffPolicy(policy)
+        return policy.build(left, right, **differ_options)
 
     def report_pair(self, level: TreeLevel):
         """Report pair of json path
@@ -619,9 +629,10 @@ class YouchamaJsonDiffer:
     def _compare_list_without_order_post(self, pair_list: List[ListItemPair], level: TreeLevel):
         matched_left_index = []
         matched_right_index = []
+        score = 0
         for pair in pair_list:
             # still can be different under not drill
-            self.diff_level(pair.level, False)
+            score += self.diff_level(pair.level, False)
             self.report_pair(pair.level)
             matched_left_index.append(pair.left_index)
             matched_right_index.append(pair.right_index)
@@ -644,8 +655,10 @@ class YouchamaJsonDiffer:
 
         for tl in delta:
             # 这样子取报告
-            self.diff_level(tl, False)
+            score += self.diff_level(tl, False)
             self.report_pair(tl)
+
+        return score
 
     def compare_list_without_order(self, level: TreeLevel, drill=False) -> float:
 
@@ -669,13 +682,16 @@ class YouchamaJsonDiffer:
                     matched_left[li] = True
                     break
 
+        resolved_score = len(pair_list)
         if not drill:
             # only in the report phase
-            self._compare_list_without_order_post(pair_list, level)
+            resolved_score = self._compare_list_without_order_post(
+                pair_list, level
+            )
 
         if max([len(level.left), len(level.right)]) == 0:
             return 1
-        return len(pair_list) / max([len(level.left), len(level.right)])
+        return resolved_score / max([len(level.left), len(level.right)])
 
     def compare_list(self, level: TreeLevel, drill=False) -> float:
         if self.ignore_order_func(level, drill):
@@ -917,6 +933,72 @@ class YouchamaJsonDiffer:
         self.diff()
         return self.to_dict(no_pairs)
 
+    def explain(self, include_diff=True):
+        """Return an executive summary plus the structured diff.
+
+        The summary separates structural/value changes from business-rule
+        evaluations and violations, making results suitable for CI messages,
+        audit logs, dashboards, and AI agents without parsing event details.
+        """
+        equal = self.diff()
+        diff_result = self.to_dict()
+        standard_events = {
+            EVENT_DICT_ADD,
+            EVENT_DICT_REMOVE,
+            EVENT_LIST_ADD,
+            EVENT_LIST_REMOVE,
+            EVENT_VALUE_CHANGE,
+        }
+        event_counts = {
+            event: len(records)
+            for event, records in diff_result.items()
+            if event != EVENT_PAIR and records
+        }
+        rule_events = {
+            event: count
+            for event, count in event_counts.items()
+            if event not in standard_events
+        }
+        violations = []
+        for event in rule_events:
+            for record in diff_result[event]:
+                if record.get("pass") is False:
+                    violations.append({"event": event, **record})
+
+        affected_paths = set()
+        for event in standard_events:
+            for record in diff_result.get(event, []):
+                path = record.get("right_path") or record.get("left_path")
+                if path:
+                    affected_paths.add(path)
+        for record in violations:
+            path = record.get("right_path") or record.get("left_path")
+            if path:
+                affected_paths.add(path)
+
+        summary = {
+            "equal": equal,
+            "change_count": sum(
+                len(diff_result.get(event, [])) for event in standard_events
+            ),
+            "rule_evaluation_count": sum(rule_events.values()),
+            "rule_violation_count": len(violations),
+            "matched_pair_count": len(diff_result.get(EVENT_PAIR, [])),
+            "affected_paths": sorted(affected_paths),
+            "events": event_counts,
+        }
+        if self.business_policy is not None:
+            summary["policy"] = self.business_policy
+
+        explanation = {
+            "equal": equal,
+            "summary": summary,
+            "violations": violations,
+        }
+        if include_diff:
+            explanation["diff"] = diff_result
+        return explanation
+
     def to_json_patch(self, include_tests=False):
         """Return an RFC 6902 JSON Patch from ``left`` to ``right``.
 
@@ -966,7 +1048,14 @@ class YouchamaJsonDiffer:
             # matching algorithm says so; otherwise positional patching still
             # guarantees a deterministic transformation.
             if isinstance(left, list) and self.ignore_order_func(level, False):
-                return self.diff_level(level, drill=True) == 1
+                isolated = YouchamaJsonDiffer(
+                    left,
+                    right,
+                    custom_operators=self.custom_operators,
+                    ignore_order_func=self.ignore_order_func,
+                    use_cache=self.use_cache,
+                )
+                return isolated.diff_level(level, drill=False) == 1
 
             return False
 

--- a/jycm/operator.py
+++ b/jycm/operator.py
@@ -11,9 +11,15 @@ if TYPE_CHECKING:
 class BaseOperator:
     __operator_name__ = "__base__"
 
-    def __init__(self, path_regex: str):
+    def __init__(self, path_regex: str, rule_name=None):
         self.path_regex = path_regex
         self.regex = re.compile(f"{self.path_regex}")
+        self.rule_name = rule_name
+
+    def rule_info(self):
+        if self.rule_name is None:
+            return {}
+        return {"rule": self.rule_name}
 
     def match(self, level: 'TreeLevel') -> bool:
         matched = self.regex.search(level.get_path()) is not None
@@ -56,8 +62,8 @@ class ListItemFieldMatchOperator(BaseOperator):
     __operator_name__ = "operator:list:matchWithField"
     __event__ = "operator:list:matchWithField"
 
-    def __init__(self, path_regex, field):
-        super().__init__(path_regex=path_regex)
+    def __init__(self, path_regex, field, rule_name=None):
+        super().__init__(path_regex=path_regex, rule_name=rule_name)
         self.field = field
 
     def diff(self, level: 'TreeLevel', instance: 'YouchamaJsonDiffer', drill: bool) -> Tuple[bool, float]:
@@ -66,7 +72,11 @@ class ListItemFieldMatchOperator(BaseOperator):
             if level.left[self.field] == level.right[self.field]:
                 return True, 1
         else:
-            instance.report(self.__event__, level, {"field": self.field, "path_regex": self.path_regex})
+            instance.report(self.__event__, level, {
+                "field": self.field,
+                "path_regex": self.path_regex,
+                **self.rule_info()
+            })
 
         return False, -1
 
@@ -79,11 +89,19 @@ class ExpectChangeOperator(BaseOperator):
     def diff(self, level: 'TreeLevel', instance: 'YouchamaJsonDiffer', drill: bool) -> Tuple[bool, float]:
         if level.left == level.right:
             if not drill:
-                instance.report(self.__event__, level, {"pass": False, "path_regex": self.path_regex})
+                instance.report(self.__event__, level, {
+                    "pass": False,
+                    "path_regex": self.path_regex,
+                    **self.rule_info()
+                })
             return True, 0
 
         if not drill:
-            instance.report(self.__event__, level, {"pass": True, "path_regex": self.path_regex})
+            instance.report(self.__event__, level, {
+                "pass": True,
+                "path_regex": self.path_regex,
+                **self.rule_info()
+            })
 
         return True, 1
 
@@ -97,7 +115,8 @@ class ExpectExistOperator(BaseOperator):
 
         info = {
             "pass": True,
-            "path_regex": self.path_regex
+            "path_regex": self.path_regex,
+            **self.rule_info()
         }
 
         if level.left == PLACE_HOLDER_NON_EXIST:
@@ -123,8 +142,8 @@ class FloatInRangeOperator(BaseOperator):
     __operator_name__ = "operator:floatInRange"
     __event__ = "operator:floatInRange"
 
-    def __init__(self, path_regex, interval_start, interval_end):
-        super().__init__(path_regex=path_regex)
+    def __init__(self, path_regex, interval_start, interval_end, rule_name=None):
+        super().__init__(path_regex=path_regex, rule_name=rule_name)
         self.interval_start = interval_start
         self.interval_end = interval_end
 
@@ -133,7 +152,8 @@ class FloatInRangeOperator(BaseOperator):
             "interval_start": self.interval_start,
             "interval_end": self.interval_end,
             "path_regex": self.path_regex,
-            "pass": True
+            "pass": True,
+            **self.rule_info()
         }
 
         invalid = False
@@ -163,14 +183,105 @@ class IgnoreOperator(BaseOperator):
     __event__ = "ignore"
 
     def __init__(self, path_regex: str, *args, **kwargs):
-        super().__init__(path_regex)
+        super().__init__(path_regex, rule_name=kwargs.get("rule_name"))
 
     def diff(self, level: 'TreeLevel', instance: 'YouchamaJsonDiffer', drill: bool) -> Tuple[bool, float]:
         info = {
             "path_regex": self.path_regex,
-            "pass": True
+            "pass": True,
+            **self.rule_info()
         }
         if not drill:
             instance.report(self.__event__, level, info)
 
         return True, 1
+
+
+@register_operator
+class NumericToleranceOperator(BaseOperator):
+    """Compare numeric values with absolute and relative business tolerances."""
+
+    __operator_name__ = ["operator:number:tolerance", "numeric_tolerance"]
+    __event__ = "operator:number:tolerance"
+
+    def __init__(self, path_regex, absolute_tolerance=0,
+                 relative_tolerance=0, rule_name=None):
+        super().__init__(path_regex=path_regex, rule_name=rule_name)
+        if absolute_tolerance < 0 or relative_tolerance < 0:
+            raise ValueError("numeric tolerances must be non-negative")
+        self.absolute_tolerance = absolute_tolerance
+        self.relative_tolerance = relative_tolerance
+
+    def diff(self, level: 'TreeLevel', instance: 'YouchamaJsonDiffer',
+             drill: bool) -> Tuple[bool, float]:
+        numeric = all((
+            isinstance(level.left, (int, float)),
+            not isinstance(level.left, bool),
+            isinstance(level.right, (int, float)),
+            not isinstance(level.right, bool),
+        ))
+        delta = abs(level.left - level.right) if numeric else None
+        scale = max(abs(level.left), abs(level.right)) if numeric else 0
+        threshold = max(
+            self.absolute_tolerance,
+            self.relative_tolerance * scale
+        )
+        passed = numeric and delta <= threshold
+        info = {
+            "pass": passed,
+            "path_regex": self.path_regex,
+            "absolute_tolerance": self.absolute_tolerance,
+            "relative_tolerance": self.relative_tolerance,
+            "delta": delta,
+            "threshold": threshold,
+            **self.rule_info()
+        }
+        if not drill:
+            instance.report(self.__event__, level, info)
+        return True, 1 if passed else 0
+
+
+@register_operator
+class StringNormalizeOperator(BaseOperator):
+    """Compare strings after configurable, explainable normalization."""
+
+    __operator_name__ = ["operator:string:normalize", "string_normalize"]
+    __event__ = "operator:string:normalize"
+
+    def __init__(self, path_regex, trim=True, lowercase=False,
+                 collapse_whitespace=False, rule_name=None):
+        super().__init__(path_regex=path_regex, rule_name=rule_name)
+        self.trim = trim
+        self.lowercase = lowercase
+        self.collapse_whitespace = collapse_whitespace
+
+    def normalize(self, value):
+        if not isinstance(value, str):
+            return value
+        if self.trim:
+            value = value.strip()
+        if self.collapse_whitespace:
+            value = " ".join(value.split())
+        if self.lowercase:
+            value = value.lower()
+        return value
+
+    def diff(self, level: 'TreeLevel', instance: 'YouchamaJsonDiffer',
+             drill: bool) -> Tuple[bool, float]:
+        strings = isinstance(level.left, str) and isinstance(level.right, str)
+        normalized_left = self.normalize(level.left)
+        normalized_right = self.normalize(level.right)
+        passed = strings and normalized_left == normalized_right
+        info = {
+            "pass": passed,
+            "path_regex": self.path_regex,
+            "normalized_left": normalized_left,
+            "normalized_right": normalized_right,
+            "trim": self.trim,
+            "lowercase": self.lowercase,
+            "collapse_whitespace": self.collapse_whitespace,
+            **self.rule_info()
+        }
+        if not drill:
+            instance.report(self.__event__, level, info)
+        return True, 1 if passed else 0

--- a/jycm/patch.py
+++ b/jycm/patch.py
@@ -1,0 +1,201 @@
+"""RFC 6902 JSON Patch generation and application for JYCM."""
+
+from copy import deepcopy
+
+
+class JsonPatchError(ValueError):
+    """Raised when a JSON Patch operation is invalid or cannot be applied."""
+
+
+class JsonPatchTestFailed(JsonPatchError):
+    """Raised when an RFC 6902 ``test`` operation does not match."""
+
+
+def _escape(token):
+    return str(token).replace("~", "~0").replace("/", "~1")
+
+
+def _tokens(path):
+    if path == "":
+        return []
+    if not isinstance(path, str) or not path.startswith("/"):
+        raise JsonPatchError("JSON Pointer paths must be empty or start with '/'")
+    return [token.replace("~1", "/").replace("~0", "~") for token in path[1:].split("/")]
+
+
+def _join(path, token):
+    return path + "/" + _escape(token)
+
+
+def _index(token, length, allow_end=False):
+    if token == "-" and allow_end:
+        return length
+    try:
+        index = int(token)
+    except (TypeError, ValueError):
+        raise JsonPatchError("Invalid array index: {!r}".format(token))
+    upper = length if allow_end else length - 1
+    if index < 0 or index > upper:
+        raise JsonPatchError("Array index out of bounds: {}".format(index))
+    return index
+
+
+def _resolve(document, path):
+    value = document
+    for token in _tokens(path):
+        if isinstance(value, list):
+            value = value[_index(token, len(value))]
+        elif isinstance(value, dict):
+            if token not in value:
+                raise JsonPatchError("Path does not exist: {}".format(path))
+            value = value[token]
+        else:
+            raise JsonPatchError("Cannot traverse path: {}".format(path))
+    return value
+
+
+def _parent(document, path):
+    tokens = _tokens(path)
+    if not tokens:
+        return None, None
+    parent = document
+    for token in tokens[:-1]:
+        if isinstance(parent, list):
+            parent = parent[_index(token, len(parent))]
+        elif isinstance(parent, dict) and token in parent:
+            parent = parent[token]
+        else:
+            raise JsonPatchError("Parent path does not exist: {}".format(path))
+    return parent, tokens[-1]
+
+
+def _add(document, path, value):
+    if path == "":
+        return value
+    parent, token = _parent(document, path)
+    if isinstance(parent, list):
+        parent.insert(_index(token, len(parent), allow_end=True), value)
+    elif isinstance(parent, dict):
+        parent[token] = value
+    else:
+        raise JsonPatchError("Add target is not a container: {}".format(path))
+    return document
+
+
+def _remove(document, path):
+    if path == "":
+        raise JsonPatchError("Removing the document root is not supported")
+    parent, token = _parent(document, path)
+    if isinstance(parent, list):
+        del parent[_index(token, len(parent))]
+    elif isinstance(parent, dict) and token in parent:
+        del parent[token]
+    else:
+        raise JsonPatchError("Remove path does not exist: {}".format(path))
+    return document
+
+
+def apply_json_patch(document, patch, in_place=False):
+    """Apply RFC 6902 operations and return the patched document.
+
+    All six standard operations are supported: ``add``, ``remove``,
+    ``replace``, ``move``, ``copy`` and ``test``. Input is copied by default.
+    """
+    result = document if in_place else deepcopy(document)
+    for operation in patch:
+        if not isinstance(operation, dict) or "op" not in operation or "path" not in operation:
+            raise JsonPatchError("Each patch operation requires 'op' and 'path'")
+        op = operation["op"]
+        path = operation["path"]
+
+        if op == "test":
+            if "value" not in operation or _resolve(result, path) != operation["value"]:
+                raise JsonPatchTestFailed("Test failed at path: {}".format(path))
+        elif op == "add":
+            if "value" not in operation:
+                raise JsonPatchError("Add operation requires 'value'")
+            result = _add(result, path, deepcopy(operation["value"]))
+        elif op == "remove":
+            result = _remove(result, path)
+        elif op == "replace":
+            if "value" not in operation:
+                raise JsonPatchError("Replace operation requires 'value'")
+            if path != "":
+                _resolve(result, path)
+                result = _remove(result, path)
+            result = _add(result, path, deepcopy(operation["value"]))
+        elif op in ("move", "copy"):
+            if "from" not in operation:
+                raise JsonPatchError("{} operation requires 'from'".format(op.title()))
+            value = deepcopy(_resolve(result, operation["from"]))
+            if op == "move":
+                result = _remove(result, operation["from"])
+            result = _add(result, path, value)
+        else:
+            raise JsonPatchError("Unsupported patch operation: {}".format(op))
+    return result
+
+
+def make_json_patch(left, right, equivalent=None, include_tests=False):
+    """Build a deterministic RFC 6902 patch.
+
+    ``equivalent`` may implement business semantics. It receives left/right
+    values and their token paths; returning true suppresses changes below that
+    node. Lists are updated positionally for linear runtime and deterministic
+    patches, while dictionaries are traversed by sorted key.
+    """
+    operations = []
+
+    def add_test(path, value):
+        if include_tests:
+            operations.append({"op": "test", "path": path, "value": deepcopy(value)})
+
+    def walk(left_value, right_value, left_path, right_path, pointer):
+        if left_value == right_value:
+            return
+        if equivalent is not None and equivalent(left_value, right_value, left_path, right_path):
+            return
+
+        if isinstance(left_value, dict) and isinstance(right_value, dict):
+            removed = sorted(set(left_value) - set(right_value), key=str)
+            added = sorted(set(right_value) - set(left_value), key=str)
+            common = sorted(set(left_value) & set(right_value), key=str)
+            for key in removed:
+                child_pointer = _join(pointer, key)
+                add_test(child_pointer, left_value[key])
+                operations.append({"op": "remove", "path": child_pointer})
+            for key in common:
+                walk(
+                    left_value[key], right_value[key],
+                    left_path + [key], right_path + [key], _join(pointer, key)
+                )
+            for key in added:
+                operations.append({
+                    "op": "add", "path": _join(pointer, key),
+                    "value": deepcopy(right_value[key])
+                })
+            return
+
+        if isinstance(left_value, list) and isinstance(right_value, list):
+            shared = min(len(left_value), len(right_value))
+            for index in range(shared):
+                walk(
+                    left_value[index], right_value[index],
+                    left_path + [index], right_path + [index], _join(pointer, index)
+                )
+            for index in range(len(left_value) - 1, shared - 1, -1):
+                child_pointer = _join(pointer, index)
+                add_test(child_pointer, left_value[index])
+                operations.append({"op": "remove", "path": child_pointer})
+            for index in range(shared, len(right_value)):
+                operations.append({
+                    "op": "add", "path": _join(pointer, index),
+                    "value": deepcopy(right_value[index])
+                })
+            return
+
+        add_test(pointer, left_value)
+        operations.append({"op": "replace", "path": pointer, "value": deepcopy(right_value)})
+
+    walk(left, right, [], [], "")
+    return operations

--- a/jycm/policy.py
+++ b/jycm/policy.py
@@ -1,0 +1,185 @@
+"""Declarative, serializable business comparison policies for JYCM."""
+
+from copy import deepcopy
+
+from jycm.helper import make_ignore_order_func
+from jycm.operator import (
+    ExpectChangeOperator,
+    ExpectExistOperator,
+    FloatInRangeOperator,
+    IgnoreOperator,
+    ListItemFieldMatchOperator,
+    NumericToleranceOperator,
+    StringNormalizeOperator,
+)
+
+
+class BusinessPolicyError(ValueError):
+    """Raised when a business comparison policy is invalid."""
+
+
+_OPERATION_ALIASES = {
+    "ignore": "ignore",
+    "unordered": "unordered",
+    "ignore_order": "unordered",
+    "operator:list:ignoreOrder": "unordered",
+    "match_by": "match_by",
+    "operator:list:matchWithField": "match_by",
+    "numeric_tolerance": "numeric_tolerance",
+    "operator:number:tolerance": "numeric_tolerance",
+    "string_normalize": "string_normalize",
+    "operator:string:normalize": "string_normalize",
+    "expect_change": "expect_change",
+    "operator:expectChange": "expect_change",
+    "expect_exist": "expect_exist",
+    "operator:expectExist": "expect_exist",
+    "range": "range",
+    "operator:floatInRange": "range",
+}
+
+
+class BusinessDiffPolicy:
+    """Compile JSON-friendly business rules into JYCM operators.
+
+    Rules are evaluated by path and can ignore volatile values, treat selected
+    lists as unordered, match list records by a business key, compare numbers
+    with tolerances, normalize strings, and express expectations.
+    """
+
+    VERSION = 1
+
+    def __init__(self, policy=None):
+        if policy is None:
+            policy = {"version": self.VERSION, "rules": []}
+        if isinstance(policy, list):
+            policy = {"version": self.VERSION, "rules": policy}
+        if not isinstance(policy, dict):
+            raise BusinessPolicyError("policy must be an object or a list of rules")
+
+        version = policy.get("version", self.VERSION)
+        if version != self.VERSION:
+            raise BusinessPolicyError(
+                "unsupported policy version: {}".format(version)
+            )
+        rules = policy.get("rules", [])
+        if not isinstance(rules, list):
+            raise BusinessPolicyError("policy.rules must be a list")
+
+        self.name = policy.get("name")
+        self.rules = [self._normalize_rule(rule, index)
+                      for index, rule in enumerate(rules)]
+
+    @classmethod
+    def from_dict(cls, policy):
+        return cls(policy)
+
+    def _normalize_rule(self, rule, index):
+        if not isinstance(rule, dict):
+            raise BusinessPolicyError("rule {} must be an object".format(index))
+        operation = rule.get("operation")
+        if operation not in _OPERATION_ALIASES:
+            raise BusinessPolicyError(
+                "rule {} has unsupported operation: {}".format(index, operation)
+            )
+        path = rule.get("path", rule.get("value"))
+        if not isinstance(path, str) or not path:
+            raise BusinessPolicyError(
+                "rule {} requires a non-empty path regex".format(index)
+            )
+        options = rule.get("options", rule.get("parameter", {}))
+        if options is None:
+            options = {}
+        if not isinstance(options, dict):
+            raise BusinessPolicyError("rule {} options must be an object".format(index))
+
+        normalized = {
+            "name": rule.get("name") or "rule-{}".format(index + 1),
+            "path": path,
+            "operation": _OPERATION_ALIASES[operation],
+            "options": deepcopy(options),
+        }
+        if normalized["operation"] == "match_by":
+            field = options.get("field")
+            if not isinstance(field, str) or not field:
+                raise BusinessPolicyError(
+                    "match_by rule {} requires options.field".format(index)
+                )
+        return normalized
+
+    def compile(self):
+        operators = []
+        unordered_paths = []
+        for rule in self.rules:
+            operation = rule["operation"]
+            path = rule["path"]
+            options = rule["options"]
+            name = rule["name"]
+
+            if operation == "unordered":
+                unordered_paths.append(path)
+            elif operation == "ignore":
+                operators.append(IgnoreOperator(path, rule_name=name))
+            elif operation == "match_by":
+                operators.append(ListItemFieldMatchOperator(
+                    path, options["field"], rule_name=name
+                ))
+            elif operation == "numeric_tolerance":
+                operators.append(NumericToleranceOperator(
+                    path,
+                    absolute_tolerance=options.get("absolute", 0),
+                    relative_tolerance=options.get("relative", 0),
+                    rule_name=name,
+                ))
+            elif operation == "string_normalize":
+                operators.append(StringNormalizeOperator(
+                    path,
+                    trim=options.get("trim", True),
+                    lowercase=options.get("lowercase", False),
+                    collapse_whitespace=options.get(
+                        "collapse_whitespace", False
+                    ),
+                    rule_name=name,
+                ))
+            elif operation == "expect_change":
+                operators.append(ExpectChangeOperator(path, rule_name=name))
+            elif operation == "expect_exist":
+                operators.append(ExpectExistOperator(path, rule_name=name))
+            elif operation == "range":
+                if "start" not in options or "end" not in options:
+                    raise BusinessPolicyError(
+                        "range rule {} requires options.start and options.end".format(name)
+                    )
+                operators.append(FloatInRangeOperator(
+                    path,
+                    options["start"],
+                    options["end"],
+                    rule_name=name,
+                ))
+
+        return {
+            "custom_operators": operators,
+            "ignore_order_func": make_ignore_order_func(unordered_paths),
+        }
+
+    def build(self, left, right, **differ_options):
+        from jycm.jycm import YouchamaJsonDiffer
+
+        compiled = self.compile()
+        compiled.update(differ_options)
+        differ = YouchamaJsonDiffer(left, right, **compiled)
+        differ.business_policy = self.to_dict()
+        return differ
+
+    def compare(self, left, right, include_diff=True, **differ_options):
+        return self.build(left, right, **differ_options).explain(
+            include_diff=include_diff
+        )
+
+    def to_dict(self):
+        result = {
+            "version": self.VERSION,
+            "rules": deepcopy(self.rules),
+        }
+        if self.name is not None:
+            result["name"] = self.name
+        return result

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,5 @@ flake8>=5.0.0
 mypy>=0.620; python_version>="3.4"
 tox>=3.0.0,<4.0.0
 isort>=4.0.0,<5.0.0
-pytest>=4.0.0,<5.0.0
-pytest-cov==2.12.1
+pytest>=7.4.0,<9.0.0
+pytest-cov>=4.1.0,<7.0.0

--- a/skills/jycm-business-diff/SKILL.md
+++ b/skills/jycm-business-diff/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: jycm-business-diff
+description: Design, implement, validate, explain, and deploy business-aware JSON comparisons with JYCM in Python or JavaScript. Use when an agent must write semantic diff rules, ignore volatile fields, match array records by identity, compare unordered collections, add numeric tolerances or string normalization, generate RFC 6902 JSON Patch, integrate the React viewer, build regression fixtures, or deploy a business diff service.
+---
+
+# JYCM Business Diff
+
+Build a versioned Business Diff Policy from concrete domain examples, prove it
+against fixtures, and expose both human-review and machine-actionable outputs.
+
+## Workflow
+
+1. Inspect the repository language, package manager, existing JYCM version, and
+   current diff fixtures. Do not replace an established integration blindly.
+2. Collect at least one equivalent pair and one meaningful-difference pair.
+   Infer rules only from explicit business meaning; flag uncertain semantics.
+3. Author a version 1 policy. Read [references/policy-schema.md](references/policy-schema.md)
+   for operation definitions, path patterns, and design constraints.
+4. Validate and normalize the policy:
+
+   ```bash
+   python scripts/jycm_workflow.py validate policy.json
+   ```
+
+5. Compare representative documents and generate an executable patch:
+
+   ```bash
+   python scripts/jycm_workflow.py compare before.json after.json policy.json \
+     --explain-out explanation.json --patch-out change.patch.json --include-tests
+   ```
+
+6. Review `summary`, named `violations`, `affected_paths`, and every patch
+   operation. Add regression tests for pass, fail, missing-field, reordered-list,
+   wrong-type, and tolerance-boundary cases.
+7. Integrate the appropriate API and UI. Keep policy files independent of
+   runtime code so Python and JavaScript services can share them.
+8. Read [references/deployment.md](references/deployment.md) when adding CI,
+   HTTP services, containers, viewer deployment, or agent installation.
+
+## Policy design rules
+
+- Apply `unordered` to the list container and `match_by` to its item path.
+- Treat identity matching as pairing only. Child rules determine equality.
+- Never apply numeric tolerance to IDs, counts requiring exactness, permission
+  levels, or security decisions without an explicit domain requirement.
+- Name every production rule with business language, not implementation jargon.
+- Prefer narrow anchored path regexes. Test that a rule does not match siblings.
+- Keep absolute and relative tolerance intentional and cover exact boundaries.
+- Use `ignore` only for fields proven irrelevant. Do not hide unknown changes.
+- Preserve `explain()` results in CI or audit flows; do not reduce the result to
+  a single boolean when violations must be reviewable.
+- Generate Patch from the same configured differ. Never derive Patch from a
+  separate raw structural diff.
+- Remember that a semantic Patch may intentionally leave ignored or reordered
+  values unchanged. Verify the patched result semantically, not by raw equality.
+
+## Runtime patterns
+
+Python:
+
+```python
+import json
+from jycm import BusinessDiffPolicy
+
+policy = BusinessDiffPolicy(json.load(open("policy.json")))
+differ = policy.build(before, after)
+explanation = differ.explain()
+patch = differ.to_json_patch(include_tests=True)
+```
+
+JavaScript/TypeScript:
+
+```ts
+import { YouchamaJsonDiffer } from "jycm";
+import policy from "./policy.json";
+
+const differ = YouchamaJsonDiffer.fromPolicy(before, after, policy);
+const explanation = differ.explain();
+const patch = differ.toJsonPatch(true);
+```
+
+React:
+
+```tsx
+<JYCMViewer left={before} right={after} diffResult={explanation.diff} showSummary />
+<JYCMPatchViewer patch={patch} onNavigate={focusJsonPointer} />
+```
+
+## Completion checks
+
+- Validate the policy successfully.
+- Prove equivalent and violating fixtures behave as intended.
+- Apply the generated patch without mutating the source document.
+- Confirm the patched result is semantically equivalent to the target.
+- Run repository lint, type, test, and production-build commands.
+- Document policy ownership, versioning, rollback, and deployment behavior.
+- Report any rules based on assumptions rather than approved domain semantics.
+
+## Installation helper
+
+From a checkout of this repository, install this skill without manually copying
+files:
+
+```bash
+python skills/jycm-business-diff/scripts/install_skill.py --client codex
+python skills/jycm-business-diff/scripts/install_skill.py --client claude
+python skills/jycm-business-diff/scripts/install_skill.py --client agents --project .
+```
+
+Existing installations are backed up only when `--force` is supplied.

--- a/skills/jycm-business-diff/agents/openai.yaml
+++ b/skills/jycm-business-diff/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "JYCM Business Diff"
+  short_description: "Design, validate, and deploy semantic JSON diffs"
+  default_prompt: "Use $jycm-business-diff to design and validate a portable business diff policy for this project."

--- a/skills/jycm-business-diff/references/deployment.md
+++ b/skills/jycm-business-diff/references/deployment.md
@@ -1,0 +1,68 @@
+# Integration and deployment
+
+## Agent installation
+
+Run `scripts/install_skill.py` from this skill checkout.
+
+- Codex user scope: `--client codex` installs to `~/.codex/skills`.
+- Claude user scope: `--client claude` installs to `~/.claude/skills`.
+- Open Agent Skills project scope: `--client agents --project .` installs to
+  `.agents/skills`.
+- Claude project scope: `--client claude --project .` installs to
+  `.claude/skills`.
+
+Use `--force` to back up an existing installation and replace it. Commit
+project-scoped skills so the whole team receives the same workflow.
+
+## Service boundary
+
+Accept three explicit inputs: `before`, `after`, and a versioned policy ID or
+policy document. Return:
+
+```json
+{
+  "equal": false,
+  "summary": {},
+  "violations": [],
+  "diff": {},
+  "patch": []
+}
+```
+
+Validate policy documents at configuration-write time and again when loading a
+new version. Reject unsupported versions and invalid regexes before comparing
+production data.
+
+## CI pattern
+
+1. Store fixtures under source control.
+2. Validate the policy.
+3. Compare each expected-equivalent and expected-different fixture.
+4. Fail on unexpected equality or named rule violations.
+5. Save `explanation.json` and Patch as build artifacts when review is needed.
+6. Apply Patch to a copy and re-run semantic comparison against the target.
+
+Use `--fail-on-difference` with `scripts/jycm_workflow.py` only for fixtures that
+must be semantically equal. For negative fixtures, assert the expected rule name
+and affected path in the test framework.
+
+## Deployment choices
+
+- Python service: package `jycm`, cache compiled policies, and create a fresh
+  differ for each request.
+- Node/browser service: package `jycm`; do not execute user-provided code for
+  custom rules. Prefer the declarative Policy operations.
+- Review UI: deploy `react-jycm-viewer` with `JYCMViewer`, `showSummary`, and the
+  standalone `JYCMPatchViewer`.
+- Static demo: avoid embedding secrets or private payloads; comparisons run in
+  the browser only when data is safe for the client.
+
+## Operational safeguards
+
+- Limit document size, list cardinality, regex length, and request duration.
+- Treat policies as executable configuration requiring ownership and review.
+- Log policy name/version and summary, not sensitive full documents by default.
+- Use RFC 6902 `test` operations for optimistic concurrency before destructive
+  writes.
+- Roll back by selecting the previous immutable policy version, not by editing
+  historical policy content in place.

--- a/skills/jycm-business-diff/references/policy-schema.md
+++ b/skills/jycm-business-diff/references/policy-schema.md
@@ -1,0 +1,77 @@
+# Business Diff Policy v1
+
+## Shape
+
+```json
+{
+  "version": 1,
+  "name": "order-contract",
+  "rules": [
+    {
+      "name": "money-rounding",
+      "path": "^items->\\[\\d+\\]->price$",
+      "operation": "numeric_tolerance",
+      "options": { "absolute": 0.01, "relative": 0.001 }
+    }
+  ]
+}
+```
+
+Paths use JYCM path keys: object fields are separated by `->` and array indexes
+look like `[0]`. Rules use regular expressions, so escape brackets in JSON.
+
+## Operations
+
+| Operation | Target | Options | Meaning |
+| --- | --- | --- | --- |
+| `ignore` | any path | none | Treat the entire matched subtree as equivalent. |
+| `unordered` | list container | none | Match list members without positional ordering. |
+| `match_by` | list item | `field` | Pair object items whose identity field is equal. |
+| `numeric_tolerance` | number | `absolute`, `relative` | Pass when delta is within the larger configured threshold. |
+| `string_normalize` | string | `trim`, `lowercase`, `collapse_whitespace` | Compare normalized strings. |
+| `expect_change` | any matched value | none | Pass only when left and right differ. |
+| `expect_exist` | any matched path | none | Pass only when both sides exist. |
+| `range` | number | `start`, `end` | Require both values in `(start, end]`. |
+
+Legacy operation names plus `value` and `parameter` fields remain accepted, but
+new policies should use the canonical shape above.
+
+## Common patterns
+
+Unordered records matched by SKU:
+
+```json
+[
+  { "name": "items-are-a-set", "path": "^items$", "operation": "unordered" },
+  {
+    "name": "match-item-sku",
+    "path": "^items->\\[\\d+\\]$",
+    "operation": "match_by",
+    "options": { "field": "sku" }
+  }
+]
+```
+
+Volatile metadata plus normalized labels:
+
+```json
+[
+  { "name": "generated-trace", "path": "^metadata->trace_id$", "operation": "ignore" },
+  {
+    "name": "canonical-label",
+    "path": "^items->\\[\\d+\\]->label$",
+    "operation": "string_normalize",
+    "options": { "trim": true, "lowercase": true, "collapse_whitespace": true }
+  }
+]
+```
+
+## Review checklist
+
+- Does each path match only the intended business field?
+- Can duplicate identity values occur? If yes, define the expected behavior.
+- Are missing values distinct from `null`, empty strings, zero, and false?
+- Is tolerance symmetric and correct at zero and for negative values?
+- Should ignored values also be excluded from generated Patch?
+- Does a passing expectation mean the entire document may be considered equal?
+- Are policy changes reviewed and versioned like application code?

--- a/skills/jycm-business-diff/scripts/install_skill.py
+++ b/skills/jycm-business-diff/scripts/install_skill.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Install the bundled Agent Skill for Codex, Claude, or project agents."""
+
+import argparse
+import shutil
+from datetime import datetime
+from pathlib import Path
+
+
+SKILL_NAME = "jycm-business-diff"
+
+
+def target_path(client, project=None):
+    if project:
+        root = Path(project).expanduser().resolve()
+        folder = ".claude/skills" if client == "claude" else ".agents/skills"
+        return root / folder / SKILL_NAME
+    home = Path.home()
+    folder = ".claude/skills" if client == "claude" else ".codex/skills"
+    return home / folder / SKILL_NAME
+
+
+def install(args):
+    source = Path(__file__).resolve().parents[1]
+    target = target_path(args.client, args.project)
+    if target.exists():
+        if not args.force:
+            raise SystemExit("Target already exists: {} (use --force to back it up)".format(target))
+        stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        backup = target.with_name("{}.backup-{}".format(SKILL_NAME, stamp))
+        shutil.move(str(target), str(backup))
+        print("Backed up existing skill to {}".format(backup))
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(str(source), str(target), ignore=shutil.ignore_patterns("__pycache__", "*.pyc"))
+    print("Installed {} to {}".format(SKILL_NAME, target))
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--client", choices=("codex", "claude", "agents"), required=True)
+    parser.add_argument("--project", help="install at project scope instead of user scope")
+    parser.add_argument("--force", action="store_true", help="back up and replace an existing install")
+    args = parser.parse_args()
+    if args.client == "agents" and not args.project:
+        parser.error("--client agents requires --project")
+    return install(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/jycm-business-diff/scripts/jycm_workflow.py
+++ b/skills/jycm-business-diff/scripts/jycm_workflow.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Validate JYCM policies and produce explanations plus RFC 6902 patches."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def load_local_jycm():
+    """Prefer the surrounding checkout, then fall back to an installed package."""
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "jycm" / "__init__.py").is_file():
+            sys.path.insert(0, str(parent))
+            break
+    try:
+        from jycm import BusinessDiffPolicy
+    except (ImportError, AttributeError):
+        raise SystemExit(
+            "JYCM with BusinessDiffPolicy is required. Run this script from a "
+            "current JYCM checkout or install a release that provides the API."
+        )
+    return BusinessDiffPolicy
+
+
+def read_json(path):
+    with Path(path).open("r", encoding="utf-8") as stream:
+        return json.load(stream)
+
+
+def write_json(path, value):
+    rendered = json.dumps(value, indent=2, ensure_ascii=False) + "\n"
+    if path:
+        Path(path).write_text(rendered, encoding="utf-8")
+    else:
+        sys.stdout.write(rendered)
+
+
+def validate(args):
+    policy = load_local_jycm()(read_json(args.policy))
+    policy.compile()
+    write_json(args.output, policy.to_dict())
+    return 0
+
+
+def compare(args):
+    policy = load_local_jycm()(read_json(args.policy))
+    before = read_json(args.before)
+    after = read_json(args.after)
+    differ = policy.build(before, after)
+    explanation = differ.explain()
+    patch = differ.to_json_patch(include_tests=args.include_tests)
+    patched = differ.apply_patch(patch=patch)
+    patch_is_semantically_valid = policy.build(patched, after).diff()
+    explanation["summary"]["patch_operation_count"] = len(patch)
+    explanation["summary"]["patch_semantically_valid"] = patch_is_semantically_valid
+
+    if args.explain_out:
+        write_json(args.explain_out, explanation)
+    else:
+        write_json(None, explanation)
+    if args.patch_out:
+        write_json(args.patch_out, patch)
+
+    if not patch_is_semantically_valid:
+        sys.stderr.write("Generated patch is not semantically equivalent to target.\n")
+        return 2
+    if args.fail_on_difference and not explanation["equal"]:
+        return 1
+    return 0
+
+
+def parser():
+    root = argparse.ArgumentParser(description=__doc__)
+    commands = root.add_subparsers(dest="command")
+
+    validate_parser = commands.add_parser("validate", help="validate and normalize a policy")
+    validate_parser.add_argument("policy")
+    validate_parser.add_argument("--output")
+    validate_parser.set_defaults(handler=validate)
+
+    compare_parser = commands.add_parser("compare", help="compare JSON documents")
+    compare_parser.add_argument("before")
+    compare_parser.add_argument("after")
+    compare_parser.add_argument("policy")
+    compare_parser.add_argument("--explain-out")
+    compare_parser.add_argument("--patch-out")
+    compare_parser.add_argument("--include-tests", action="store_true")
+    compare_parser.add_argument("--fail-on-difference", action="store_true")
+    compare_parser.set_defaults(handler=compare)
+    return root
+
+
+def main(argv=None):
+    arguments = parser().parse_args(argv)
+    if not hasattr(arguments, "handler"):
+        parser().print_help()
+        return 2
+    return arguments.handler(arguments)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -3,7 +3,7 @@ import pytest
 from jycm.helper import make_ignore_order_func
 from jycm.jycm import YouchamaJsonDiffer
 from jycm.operator import IgnoreOperator, ListItemFieldMatchOperator
-from jycm.patch import JsonPatchTestFailed, apply_json_patch
+from jycm.patch import JsonPatchError, JsonPatchTestFailed, apply_json_patch
 
 
 def test_json_patch_round_trip_nested_values_and_lists():
@@ -75,6 +75,50 @@ def test_json_patch_test_operation_guards_stale_documents():
 
     with pytest.raises(JsonPatchTestFailed):
         apply_json_patch({"version": 9}, patch)
+
+
+@pytest.mark.parametrize("document, patch, message", [
+    ({}, [{"op": "add", "path": "invalid", "value": 1}], "JSON Pointer"),
+    ({"items": []}, [{"op": "add", "path": "/items/-", "value": 1}], None),
+    ({"items": []}, [{"op": "remove", "path": "/items/nope"}], "Invalid array"),
+    ({"items": []}, [{"op": "remove", "path": "/items/0"}], "out of bounds"),
+    ({}, [{"op": "test", "path": "/missing", "value": 1}], "does not exist"),
+    ({"value": 1}, [{"op": "test", "path": "/value/child", "value": 1}],
+     "Cannot traverse"),
+    ({}, [{"op": "add", "path": "/missing/child", "value": 1}], "Parent path"),
+    ({"value": 1}, [{"op": "add", "path": "/value/child", "value": 1}],
+     "not a container"),
+    ({}, [{"op": "remove", "path": ""}], "document root"),
+    ({}, [{"op": "remove", "path": "/missing"}], "does not exist"),
+    ({}, [None], "requires 'op' and 'path'"),
+    ({}, [{"op": "add", "path": "/x"}], "requires 'value'"),
+    ({"x": 1}, [{"op": "replace", "path": "/x"}], "requires 'value'"),
+    ({}, [{"op": "copy", "path": "/x"}], "requires 'from'"),
+    ({}, [{"op": "unknown", "path": ""}], "Unsupported patch operation"),
+])
+def test_json_patch_rejects_invalid_operations(document, patch, message):
+    if message is None:
+        assert apply_json_patch(document, patch) == {"items": [1]}
+        return
+    with pytest.raises(JsonPatchError, match=message):
+        apply_json_patch(document, patch)
+
+
+def test_json_patch_supports_root_replacement_and_in_place_updates():
+    original = {"value": 1}
+    result = apply_json_patch(
+        original,
+        [{"op": "replace", "path": "", "value": ["root"]}],
+    )
+    assert result == ["root"]
+    assert original == {"value": 1}
+
+    assert apply_json_patch(
+        original,
+        [{"op": "replace", "path": "/value", "value": 2}],
+        in_place=True,
+    ) is original
+    assert original == {"value": 2}
 
 
 def test_large_equal_list_does_not_use_recursive_lcs_backtracking():

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -1,0 +1,83 @@
+import pytest
+
+from jycm.helper import make_ignore_order_func
+from jycm.jycm import YouchamaJsonDiffer
+from jycm.operator import IgnoreOperator, ListItemFieldMatchOperator
+from jycm.patch import JsonPatchTestFailed, apply_json_patch
+
+
+def test_json_patch_round_trip_nested_values_and_lists():
+    left = {
+        "name": "old",
+        "meta": {"removed": True, "keep": 1},
+        "items": [1, {"value": 2}, "remove-me"],
+    }
+    right = {
+        "name": "new",
+        "meta": {"added": None, "keep": 1},
+        "items": [1, {"value": 3}, "added", "tail"],
+    }
+
+    differ = YouchamaJsonDiffer(left, right)
+    patch = differ.to_json_patch(include_tests=True)
+
+    assert apply_json_patch(left, patch) == right
+    assert differ.apply_patch() == right
+    assert left["name"] == "old"
+
+
+def test_json_patch_respects_business_diff_rules():
+    left = {"generated_at": "yesterday", "tags": ["a", "b"], "amount": 10}
+    right = {"generated_at": "today", "tags": ["b", "a"], "amount": 11}
+    differ = YouchamaJsonDiffer(
+        left,
+        right,
+        custom_operators=[IgnoreOperator("^generated_at$")],
+        ignore_order_func=make_ignore_order_func(["^tags$"]),
+    )
+
+    patch = differ.to_json_patch()
+
+    assert patch == [{"op": "replace", "path": "/amount", "value": 11}]
+    assert differ.apply_patch() == {"generated_at": "yesterday", "tags": ["a", "b"], "amount": 11}
+
+
+def test_matching_operator_keeps_diffing_business_fields():
+    left = {"orders": [{"id": 7, "status": "pending"}]}
+    right = {"orders": [{"id": 7, "status": "paid"}]}
+    differ = YouchamaJsonDiffer(
+        left,
+        right,
+        custom_operators=[ListItemFieldMatchOperator(r"^orders->\[\d+\]$", "id")],
+    )
+
+    assert differ.to_json_patch() == [
+        {"op": "replace", "path": "/orders/0/status", "value": "paid"}
+    ]
+    assert differ.apply_patch() == right
+
+
+def test_apply_json_patch_supports_move_copy_and_escaped_paths():
+    document = {"a/b": ["first", "second"], "target": {}}
+    patch = [
+        {"op": "copy", "from": "/a~1b/0", "path": "/target/copied"},
+        {"op": "move", "from": "/a~1b/1", "path": "/a~1b/0"},
+    ]
+
+    assert apply_json_patch(document, patch) == {
+        "a/b": ["second", "first"],
+        "target": {"copied": "first"},
+    }
+
+
+def test_json_patch_test_operation_guards_stale_documents():
+    patch = YouchamaJsonDiffer({"version": 1}, {"version": 2}).to_json_patch(include_tests=True)
+
+    with pytest.raises(JsonPatchTestFailed):
+        apply_json_patch({"version": 9}, patch)
+
+
+def test_large_equal_list_does_not_use_recursive_lcs_backtracking():
+    values = list(range(1200))
+
+    assert YouchamaJsonDiffer(values, list(values)).diff()

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,0 +1,154 @@
+import pytest
+
+from jycm import BusinessDiffPolicy, BusinessPolicyError
+from jycm.jycm import YouchamaJsonDiffer
+
+
+def make_order_policy():
+    return BusinessDiffPolicy({
+        "version": 1,
+        "name": "order-api-contract",
+        "rules": [
+            {
+                "name": "orders-have-no-display-order",
+                "path": "^orders$",
+                "operation": "unordered",
+            },
+            {
+                "name": "orders-match-by-id",
+                "path": r"^orders->\[\d+\]$",
+                "operation": "match_by",
+                "options": {"field": "id"},
+            },
+            {
+                "name": "currency-rounding",
+                "path": r"^orders->\[\d+\]->amount$",
+                "operation": "numeric_tolerance",
+                "options": {"absolute": 0.5, "relative": 0.001},
+            },
+            {
+                "name": "customer-name-formatting",
+                "path": r"^orders->\[\d+\]->customer$",
+                "operation": "string_normalize",
+                "options": {
+                    "trim": True,
+                    "lowercase": True,
+                    "collapse_whitespace": True,
+                },
+            },
+            {
+                "name": "volatile-timestamp",
+                "path": "^generated_at$",
+                "operation": "ignore",
+            },
+        ],
+    })
+
+
+def test_declarative_policy_compiles_business_semantics_and_explains():
+    left = {
+        "generated_at": "2026-01-01T00:00:00Z",
+        "orders": [
+            {"id": "A", "amount": 100.0, "customer": " Acme   Corp "},
+            {"id": "B", "amount": 50.0, "customer": "Beta"},
+        ],
+    }
+    right = {
+        "generated_at": "2026-01-02T00:00:00Z",
+        "orders": [
+            {"id": "B", "amount": 50.02, "customer": " beta "},
+            {"id": "A", "amount": 100.4, "customer": "acme corp"},
+        ],
+    }
+
+    differ = make_order_policy().build(left, right)
+    explanation = differ.explain()
+
+    assert explanation["equal"] is True
+    assert explanation["summary"]["change_count"] == 0
+    assert explanation["summary"]["rule_violation_count"] == 0
+    assert explanation["summary"]["rule_evaluation_count"] >= 5
+    assert explanation["summary"]["policy"]["name"] == "order-api-contract"
+    assert "operator:number:tolerance" in explanation["diff"]
+    assert "operator:string:normalize" in explanation["diff"]
+    assert all(
+        record["rule"] == "currency-rounding"
+        for record in explanation["diff"]["operator:number:tolerance"]
+    )
+
+
+def test_policy_violation_is_machine_readable_and_affects_equality():
+    policy = make_order_policy()
+    left = {"orders": [{"id": "A", "amount": 100, "customer": "Acme"}]}
+    right = {"orders": [{"id": "A", "amount": 103, "customer": "Acme"}]}
+
+    explanation = policy.compare(left, right, include_diff=False)
+
+    assert explanation["equal"] is False
+    assert explanation["summary"]["rule_violation_count"] == 1
+    assert explanation["summary"]["affected_paths"] == ["orders->[0]->amount"]
+    assert explanation["violations"][0]["rule"] == "currency-rounding"
+    assert explanation["violations"][0]["delta"] == 3
+    assert "diff" not in explanation
+
+
+def test_policy_and_json_patch_share_the_same_list_semantics():
+    policy = make_order_policy()
+    left = {"orders": [{"id": "A", "amount": 100, "customer": "Acme"}]}
+
+    within_tolerance = policy.build(
+        left,
+        {"orders": [{"id": "A", "amount": 100.2, "customer": " acme "}]},
+    )
+    assert within_tolerance.diff() is True
+    assert within_tolerance.to_json_patch() == []
+
+    outside_tolerance = policy.build(
+        left,
+        {"orders": [{"id": "A", "amount": 103, "customer": "Acme"}]},
+    )
+    assert outside_tolerance.diff() is False
+    assert outside_tolerance.to_json_patch() == [
+        {"op": "replace", "path": "/orders/0/amount", "value": 103}
+    ]
+
+
+def test_differ_from_policy_accepts_legacy_rule_shape():
+    differ = YouchamaJsonDiffer.from_policy(
+        {"tags": ["a", "b"], "trace": 1},
+        {"tags": ["b", "a"], "trace": 2},
+        [
+            {"operation": "operator:list:ignoreOrder", "value": "^tags$"},
+            {"operation": "ignore", "value": "^trace$"},
+        ],
+    )
+
+    assert differ.diff() is True
+    assert differ.business_policy["version"] == 1
+
+
+@pytest.mark.parametrize("policy, message", [
+    ({"version": 2, "rules": []}, "unsupported policy version"),
+    ({"rules": {}}, "policy.rules must be a list"),
+    ({"rules": ["bad"]}, "must be an object"),
+    ({"rules": [{"path": "^x$", "operation": "unknown"}]},
+     "unsupported operation"),
+    ({"rules": [{"operation": "ignore"}]}, "requires a non-empty path"),
+    ({"rules": [{"path": "^x$", "operation": "match_by"}]},
+     "requires options.field"),
+])
+def test_policy_validation_is_actionable(policy, message):
+    with pytest.raises(BusinessPolicyError, match=message):
+        BusinessDiffPolicy(policy)
+
+
+def test_negative_numeric_tolerance_is_rejected():
+    policy = BusinessDiffPolicy({
+        "rules": [{
+            "path": "^amount$",
+            "operation": "numeric_tolerance",
+            "options": {"absolute": -1},
+        }]
+    })
+    with pytest.raises(ValueError, match="non-negative"):
+        policy.compile()

--- a/tests/test_skill_workflow.py
+++ b/tests/test_skill_workflow.py
@@ -1,0 +1,74 @@
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+
+SCRIPT = Path(__file__).parents[1].joinpath(
+    "skills", "jycm-business-diff", "scripts", "jycm_workflow.py"
+)
+INSTALLER = SCRIPT.with_name("install_skill.py")
+
+
+def dump(path, value):
+    path.write_text(json.dumps(value), encoding="utf-8")
+
+
+def test_skill_workflow_validates_compares_and_writes_patch(tmp_path):
+    policy_path = tmp_path / "policy.json"
+    before_path = tmp_path / "before.json"
+    after_path = tmp_path / "after.json"
+    normalized_path = tmp_path / "normalized.json"
+    explanation_path = tmp_path / "explanation.json"
+    patch_path = tmp_path / "patch.json"
+
+    dump(policy_path, {
+        "version": 1,
+        "name": "skill-test",
+        "rules": [{
+            "name": "rounding",
+            "path": "^amount$",
+            "operation": "numeric_tolerance",
+            "options": {"absolute": 0.1},
+        }],
+    })
+    dump(before_path, {"amount": 10, "status": "draft"})
+    dump(after_path, {"amount": 10.05, "status": "approved"})
+
+    subprocess.check_call([
+        sys.executable, str(SCRIPT), "validate", str(policy_path),
+        "--output", str(normalized_path),
+    ])
+    subprocess.check_call([
+        sys.executable, str(SCRIPT), "compare", str(before_path),
+        str(after_path), str(policy_path), "--include-tests",
+        "--explain-out", str(explanation_path),
+        "--patch-out", str(patch_path),
+    ])
+
+    normalized = json.loads(normalized_path.read_text(encoding="utf-8"))
+    explanation = json.loads(explanation_path.read_text(encoding="utf-8"))
+    patch = json.loads(patch_path.read_text(encoding="utf-8"))
+    assert normalized["name"] == "skill-test"
+    assert explanation["summary"]["patch_semantically_valid"] is True
+    assert explanation["summary"]["patch_operation_count"] == 2
+    assert patch == [
+        {"op": "test", "path": "/status", "value": "draft"},
+        {"op": "replace", "path": "/status", "value": "approved"},
+    ]
+
+
+def test_skill_installer_supports_project_agent_layout(tmp_path):
+    spec = importlib.util.spec_from_file_location("jycm_skill_installer", INSTALLER)
+    installer = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(installer)
+
+    installer.install(SimpleNamespace(
+        client="agents", project=str(tmp_path), force=False
+    ))
+
+    installed = tmp_path / ".agents" / "skills" / "jycm-business-diff"
+    assert (installed / "SKILL.md").is_file()
+    assert (installed / "scripts" / "jycm_workflow.py").is_file()


### PR DESCRIPTION
## What changed

- add a versioned, JSON-serializable `BusinessDiffPolicy` API
- add named rules for ignore, unordered arrays, identity matching, numeric tolerance, string normalization, expected change/existence, and ranges
- add `explain()` with business-level counts, affected paths, matched pairs, and machine-readable violations
- ensure identity matching does not hide child-field violations
- generate and apply RFC 6902 patches with the same semantic rules used by diff
- replace recursive LCS backtracking for large-list safety
- ship the portable `jycm-business-diff` Agent Skill for Codex, Claude Code, and open Agent Skills clients
- include deterministic policy validation/comparison and safe user/project installation scripts
- document policy design, CI, service, UI, deployment, rollback, and operational safeguards

## Why

JYCM already had powerful operators, but applications had to assemble them through runtime-specific configuration and manually interpret event dictionaries. This change adds a portable policy contract and an executive summary suitable for CI, audit logs, dashboards, and cross-language services.

The unordered-list final comparison also previously used identity matches as the final equality score. A matching key could therefore hide a failed child-field rule. Identity now controls pairing only; child comparisons control equality.

The Agent Skill makes the same workflow reusable by coding agents: derive rules from explicit business examples, validate positive and negative fixtures, verify Patch semantically, integrate the viewer, and deploy with guardrails.

## Developer impact

Existing constructors and legacy rule shapes remain supported. New applications can store one policy as JSON, use it in Python and JavaScript, inspect named violations, and generate a consistent JSON Patch. Teams can install the bundled Skill user-wide or commit it at project scope; existing installations are backed up before forced replacement.

## Validation

- `python -m pytest -q` — 44 passed
- `python -m flake8 jycm tests skills/jycm-business-diff/scripts`
- `quick_validate.py skills/jycm-business-diff` — valid
- workflow script and project-scope installer exercised by regression tests

Closes #8.
Fixes #5.
